### PR TITLE
Remove Memory Leaks (NGWPC-9203)

### DIFF
--- a/include/soil_moisture_profile.hxx
+++ b/include/soil_moisture_profile.hxx
@@ -94,8 +94,8 @@ namespace soil_moisture_profile {
     std::string verbosity;
     
     // layered model
-    double *soil_moisture_wetting_fronts;
-    double *soil_depth_wetting_fronts;
+    std::vector<double> soil_moisture_wetting_fronts{};
+    std::vector<double> soil_depth_wetting_fronts{};
     double *soil_depth_layers;
     int     num_wetting_fronts;
     int     max_num_wetting_fronts;

--- a/src/bmi_soil_moisture_profile.cxx
+++ b/src/bmi_soil_moisture_profile.cxx
@@ -374,9 +374,9 @@ GetValuePtr (std::string name)
   else if (name.compare("soil_moisture_profile") == 0)
     return (void*)this->state->soil_moisture_profile;
   else if (name.compare("soil_moisture_wetting_fronts") == 0)
-    return (void*)this->state->soil_moisture_wetting_fronts;
+    return this->state->soil_moisture_wetting_fronts.data();
   else if (name.compare("soil_depth_wetting_fronts") == 0)
-    return (void*)this->state->soil_depth_wetting_fronts;
+    return this->state->soil_depth_wetting_fronts.data();
   else if (name.compare("soil_storage_model") == 0)
     return (void*)(&this->state->soil_storage_model);
   else if (name.compare("num_wetting_fronts") == 0)
@@ -433,15 +433,19 @@ ResetSize (std::string name)
 {
 // reset the size of wetting fronts array to the number of wetting fronts at the timestep
   if (name.compare("soil_moisture_wetting_fronts") == 0) {
-    assert (this->state->num_wetting_fronts > 0);
-    state->soil_moisture_wetting_fronts = new double[this->state->num_wetting_fronts]();
+    if (this->state->num_wetting_fronts <= 0) {
+      LOG(LogLevel::SEVERE, "The number of wetting fronts must be greater than zero. The current number of wetting fronts is %d.", this->state->num_wetting_fronts);
+    }
+    state->soil_moisture_wetting_fronts.resize(this->state->num_wetting_fronts);
   }
   else if (name.compare("soil_depth_wetting_fronts") == 0) {
-    assert (this->state->num_wetting_fronts > 0);
-    state->soil_depth_wetting_fronts = new double[this->state->num_wetting_fronts]();
+    if (this->state->num_wetting_fronts <= 0) {
+      LOG(LogLevel::SEVERE, "The number of wetting fronts must be greater than zero. The current number of wetting fronts is %d.", this->state->num_wetting_fronts);
+    }
+    state->soil_depth_wetting_fronts.resize(this->state->num_wetting_fronts);
   }
 }
-  
+
 void BmiSoilMoistureProfile::
 SetValue (std::string name, void *src)
 {

--- a/src/bmi_soil_moisture_profile.cxx
+++ b/src/bmi_soil_moisture_profile.cxx
@@ -434,13 +434,17 @@ ResetSize (std::string name)
 // reset the size of wetting fronts array to the number of wetting fronts at the timestep
   if (name.compare("soil_moisture_wetting_fronts") == 0) {
     if (this->state->num_wetting_fronts <= 0) {
-      LOG(LogLevel::SEVERE, "The number of wetting fronts must be greater than zero. The current number of wetting fronts is %d.", this->state->num_wetting_fronts);
+      std::string error_msg = "The number of wetting fronts must be greater than zero. The current number of wetting fronts is " + std::to_string(this->state->num_wetting_fronts);
+      LOG(LogLevel::FATAL, error_msg);
+      throw std::out_of_range(error_msg);
     }
     state->soil_moisture_wetting_fronts.resize(this->state->num_wetting_fronts);
   }
   else if (name.compare("soil_depth_wetting_fronts") == 0) {
     if (this->state->num_wetting_fronts <= 0) {
-      LOG(LogLevel::SEVERE, "The number of wetting fronts must be greater than zero. The current number of wetting fronts is %d.", this->state->num_wetting_fronts);
+      std::string error_msg = "The number of wetting fronts must be greater than zero. The current number of wetting fronts is " + std::to_string(this->state->num_wetting_fronts);
+      LOG(LogLevel::FATAL, error_msg);
+      throw std::out_of_range(error_msg);
     }
     state->soil_depth_wetting_fronts.resize(this->state->num_wetting_fronts);
   }

--- a/src/soil_moisture_profile.cxx
+++ b/src/soil_moisture_profile.cxx
@@ -944,6 +944,9 @@ void soil_moisture_profile::SoilMoistureProfileFromWaterTableDepth(
         }
     }
 
+    delete smct_temp;
+    delete z_temp;
+
     if (Logger::GetLogLevel() == LogLevel::DEBUG) {
         LOG(LogLevel::DEBUG, "Water table depth (m) = %f ", parameters->water_table_depth);
         PrintSoilMoistureProfile(parameters);

--- a/src/soil_moisture_profile.cxx
+++ b/src/soil_moisture_profile.cxx
@@ -34,8 +34,8 @@ void soil_moisture_profile::SoilMoistureProfile(
 
     parameters->soil_moisture_profile = new double[parameters->ncells];
 
-    parameters->soil_moisture_wetting_fronts = new double[parameters->shape[1]]();
-    parameters->soil_depth_wetting_fronts    = new double[parameters->shape[1]]();
+    parameters->soil_moisture_wetting_fronts.resize(parameters->shape[1]);
+    parameters->soil_depth_wetting_fronts.resize(parameters->shape[1]);
 
     // For water_table_based_method
     parameters->cat_area           = 1.0; // catchment area used in the topmodel (normalized)

--- a/src/soil_moisture_profile.cxx
+++ b/src/soil_moisture_profile.cxx
@@ -944,8 +944,8 @@ void soil_moisture_profile::SoilMoistureProfileFromWaterTableDepth(
         }
     }
 
-    delete smct_temp;
-    delete z_temp;
+    delete[] smct_temp;
+    delete[] z_temp;
 
     if (Logger::GetLogLevel() == LogLevel::DEBUG) {
         LOG(LogLevel::DEBUG, "Water table depth (m) = %f ", parameters->water_table_depth);


### PR DESCRIPTION
A memory leak was noticed when running for many timesteps. This PR aims to fix the memory leaks that would be generated during the NGEN catchment calculations.

# Changes

- `soil_profile_parameters` struct's `soil_moisture_wetting_fronts` and `soil_depth_wetting_fronts` properties changed from `double *` to `std::vector<double>`.
- `BmiSoilMoistureProfile::ResetSize` resizes the vectors instead of creating new arrays. This approach was used over just adding `delete` to the function to improve efficiency by leveraging `std::vector::resize` optimization over required a new heap allocation every time.
- `BmiSoilMoistureProfile::GetValuePtr` gets `data()` from the vectors.
- `soil_moisture_profile::SoilMoistureProfileFromWaterTableDepth` deletes the local arrays allocated each time step.