### PR TITLE
SetValue Option for "reset_time" (NGWPC-9620)

### DIFF
--- a/include/bmi_soil_moisture_profile.hxx
+++ b/include/bmi_soil_moisture_profile.hxx
@@ -113,7 +113,7 @@ private:
   vecbuf<char> m_serialized;
   uint64_t m_serialized_length;
   void new_serialized();
-  void load_serialized(const char* data);
+  void load_serialized(char* data);
   void free_serialized();
 };
 

--- a/include/vecbuf.hpp
+++ b/include/vecbuf.hpp
@@ -28,6 +28,9 @@ public:
     // Forwarder for std::vector::clear()
     constexpr void clear() { vector_.clear(); }
 
+    // Forwarder for std::vector::resize(size)
+    constexpr void resize(size_type size) { vector_.resize(size); }
+
     // Forwarder for std::vector::reserve
     constexpr void reserve(size_type capacity) { vector_.reserve(capacity); setp_from_vector(); }
 
@@ -35,7 +38,7 @@ public:
     constexpr void reserve_additional(size_type additional_capacity) { reserve(size() + additional_capacity); }
 
     // Forwarder for std::vector::data
-    constexpr const value_type* data() const { return vector_.data(); }
+    constexpr value_type* data() { return vector_.data(); }
 
     // Forwarder for std::vector::size
     constexpr size_type size() const { return vector_.size(); }
@@ -110,6 +113,13 @@ private:
         return written;
     }
 
+};
+
+class membuf : public std::streambuf {
+public:
+    membuf(char *begin, size_t size) {
+        this->setg(begin, begin, begin + size);
+    }
 };
 
 #endif

--- a/src/bmi_soil_moisture_profile.cxx
+++ b/src/bmi_soil_moisture_profile.cxx
@@ -609,11 +609,15 @@ serialize(Archive& ar, const unsigned int version) {
 
 void BmiSoilMoistureProfile::
 new_serialized() {
-  this->m_serialized.clear();
+  // resize with space for size as a header
+  this->m_serialized.resize(sizeof(uint64_t));
   boost::archive::binary_oarchive archive(this->m_serialized);
   try {
     archive << (*this);
     this->m_serialized_length = this->m_serialized.size();
+    // store size of serialized data as header
+    uint64_t serialized_size = this->m_serialized_length - sizeof(uint64_t);
+    memcpy(this->m_serialized.data(), &serialized_size, sizeof(uint64_t));
   } catch (const std::exception &e) {
     LOG(LogLevel::WARNING, "Serializing SMP encounterd an error: %s", e.what());
     LOG(LogLevel::WARNING, "Set m_serialized_length = 0");
@@ -624,8 +628,12 @@ new_serialized() {
 
 
 void BmiSoilMoistureProfile::
-load_serialized(const char* data) {
-  std::stringstream stream(data);
+load_serialized(char* data) {
+  // get size from header of data
+  uint64_t size;
+  memcpy(&size, data, sizeof(uint64_t));
+  // create stream from after header
+  membuf stream(data + sizeof(uint64_t), size);
   boost::archive::binary_iarchive archive(stream);
   try {
     archive >> (*this);

--- a/src/bmi_soil_moisture_profile.cxx
+++ b/src/bmi_soil_moisture_profile.cxx
@@ -82,6 +82,7 @@ GetVarGrid(std::string name)
     || name.compare("global_deficit") == 0
     || name.compare("b") == 0
     || name.compare("satpsi") == 0
+    || name.compare("reset_time") == 0
   ) // double
     return 1;
   else if (
@@ -462,6 +463,9 @@ SetValue (std::string name, void *src)
     return;
   } else if (name.compare("serialization_free") == 0) {
     this->free_serialized();
+    return;
+  } else if (name == "reset_time") {
+    // This BMI does not increment its time, so no action needs to be done.
     return;
   }
   void * dest = NULL;


### PR DESCRIPTION
Hindcasting requires setting the time back to 0 after loading a previous state with time. This PR introduces using `SetValue` with the variable "reset_time" as a signal for the BMI to reset its time to 0.
No internal tracking of time was found for this model, so the implementation just prevents errors from being thrown when using the variable name.