### PR TITLE
suppress duplicate warnings

### DIFF
--- a/src/soil_moisture_profile.cxx
+++ b/src/soil_moisture_profile.cxx
@@ -458,17 +458,32 @@ void soil_moisture_profile::SoilMoistureProfileFromConceptualReservoir(
 
     double soil_storage_max = model_depth * parameters->smcmax[0];
 
+
     double soil_storage_change_per_timestep_cm =
         fabs(parameters->soil_storage_change_per_timestep * 100.0);
-    double soil_storage_current_timestep_cm =
-        100.0 * parameters->soil_storage; // storage at the current timestep
 
     if (!(parameters->soil_storage > 0.0)) {
+        static int warned = 0;
+
         // to ensure that soil storage is non-zero due to unexpected
         //  bugs (either in the models or calibration tools)
-        LOG(LogLevel::WARNING,"Invalid parameter. soil_storage = %f. Must be >= 0.0. Initializing the soil storage to 0.0001.", parameters->soil_storage);
+        if (warned == 0) {
+            LOG(LogLevel::WARNING,
+                "Invalid parameter. soil_storage = %f. Must be >= 0.0. Initializing the soil storage to 0.0001.",
+                parameters->soil_storage);
+            warned = 1;
+        }
+        else if (warned == 1) {
+            LOG(LogLevel::WARNING,
+                "Invalid soil_storage occurred again; further warnings suppressed");
+            warned = 2;
+        }
+
         parameters->soil_storage = 0.0001;
     }
+
+    double soil_storage_current_timestep_cm =
+        100.0 * parameters->soil_storage; // storage at the current timestep
 
     int count = 0;
 


### PR DESCRIPTION
https://jira.nextgenwaterprediction.com/browse/NGWPC-10674

**SMP Logging & Stability Fix – Duplicate Warning Suppression and NaN Handling**

During compound model runs (Noah-OWP, SFT, SMP, Sac-SMA, T-Route, UEB), the SoilMoistureProfiles (SMP) module produces repeated WARNING messages related to invalid soil_storage values (e.g., 0, negative, or NaN). These warnings are emitted at every timestep when the condition persists, resulting in excessive log noise.

The issue originates in: soil_moisture_profile.cxx → SoilMoistureProfileFromConceptualReservoir()

**Fix Approach**

Duplicate Log Suppression
Apply a static warning throttle pattern:
Log the full warning only once
Log a single suppression message on the second occurrence
Suppress all further repeated warnings

Numerical Stability
Ensure soil_storage is validated and corrected before use
Previously, derived variable:
soil_storage_current_timestep_cm = 100.0 * parameters->soil_storage; was computed before validation, allowing invalid values (especially NaN) to propagate into the Newton–Raphson solver.
This could lead to:
solver instability
non-convergence
corrupted soil moisture profiles

Fixed by moving the computation after validation, ensuring all downstream calculations use valid values.

**Outcome**
Eliminates duplicate warning spam
Preserves visibility of the issue
Prevents propagation of invalid (NaN) values
Improves numerical stability of the solver
Enhances overall robustness of coupled ngen-cal workflows without changing model behavior