### PR TITLE
Fix for incorrectly identified log messages

### DIFF
--- a/include/Logger.hxx
+++ b/include/Logger.hxx
@@ -2,18 +2,16 @@
 #define SMP_LOGGER_HPP
 
 #include "ewts/module_constants.hpp"
-
-// Provide the constant in the global namespace
-inline constexpr const char* EWTS_ID_SMP = ewts::modules::EWTS_ID_SMP;
-
-// Bind this module's logger identity
-#define EWTS_ID EWTS_ID_SMP
-
 #include "ewts/logger.hpp"
+#include "ewts/log_levels.hpp"
+
+#define LOG(...) ::ewts::GetLogger(::ewts::modules::EWTS_ID_SMP).Log(__VA_ARGS__)
+#define GetLogLevel() ::ewts::GetLogger(::ewts::modules::EWTS_ID_SMP).GetLogLevel()
+#define IsLoggingEnabled() ::ewts::GetLogger(::ewts::modules::EWTS_ID_SMP).IsLoggingEnabled()
 
 using ewts::EwtsInit;
 using ewts::LogLevel;
-using ewts::GetLogLevel;
 
+inline constexpr const char* SMP_MODULE_ID = ewts::modules::EWTS_ID_SMP;
 
 #endif /* SMP_LOGGER_HPP */

--- a/src/bmi_soil_moisture_profile.cxx
+++ b/src/bmi_soil_moisture_profile.cxx
@@ -22,9 +22,9 @@ Initialize (std::string config_file)
 {
     // Initialize the Error, Warning and Trapping System
 #ifdef EWTS_HAVE_NGEN_BRIDGE    
-  EwtsInit(EWTS_ID_SMP, true);
+  EwtsInit(SMP_MODULE_ID, true);
 #else
-  EwtsInit(EWTS_ID_SMP, false);
+  EwtsInit(SMP_MODULE_ID, false);
 #endif  
 
   LOG(LogLevel::INFO, "Initializing SMP");

--- a/src/soil_moisture_profile.cxx
+++ b/src/soil_moisture_profile.cxx
@@ -458,17 +458,32 @@ void soil_moisture_profile::SoilMoistureProfileFromConceptualReservoir(
 
     double soil_storage_max = model_depth * parameters->smcmax[0];
 
+
     double soil_storage_change_per_timestep_cm =
         fabs(parameters->soil_storage_change_per_timestep * 100.0);
-    double soil_storage_current_timestep_cm =
-        100.0 * parameters->soil_storage; // storage at the current timestep
 
     if (!(parameters->soil_storage > 0.0)) {
+        static int warned = 0;
+
         // to ensure that soil storage is non-zero due to unexpected
         //  bugs (either in the models or calibration tools)
-        LOG(LogLevel::WARNING,"Invalid parameter. soil_storage = %f. Must be >= 0.0. Initializing the soil storage to 0.0001.", parameters->soil_storage);
+        if (warned == 0) {
+            LOG(LogLevel::WARNING,
+                "Invalid parameter. soil_storage = %f. Must be >= 0.0. Initializing the soil storage to 0.0001.",
+                parameters->soil_storage);
+            warned = 1;
+        }
+        else if (warned == 1) {
+            LOG(LogLevel::WARNING,
+                "Invalid soil_storage occurred again; further warnings suppressed");
+            warned = 2;
+        }
+
         parameters->soil_storage = 0.0001;
     }
+
+    double soil_storage_current_timestep_cm =
+        100.0 * parameters->soil_storage; // storage at the current timestep
 
     int count = 0;
 


### PR DESCRIPTION
Remove using generic EWTS_ID and define LOG in submodule instead of relying on generic definition in ewts library which was causing log messages to be incorrectly identified in the logs.